### PR TITLE
[2/2] libhardware:  Add flag for TARGET_HAS_PREBUILT_HWC

### DIFF
--- a/include/hardware/hwcomposer.h
+++ b/include/hardware/hwcomposer.h
@@ -299,8 +299,10 @@ typedef struct hwc_layer_1 {
              */
             hwc_region_t surfaceDamage;
 
+#ifndef PREBUILT_HWC
             /* Color for Dim Layer */
             hwc_color_t color;
+#endif
         };
     };
 


### PR DESCRIPTION
Conditionally enable ABI compatibility for devices
that use a prebuilt hwcomposer

Change-Id: I8e0a547fb6a3c5cb24199e04a9b23f4ae0486885